### PR TITLE
Add basic tests for cpu

### DIFF
--- a/test/test_cpu.c
+++ b/test/test_cpu.c
@@ -1,10 +1,24 @@
 #include "cpu.h"
 #include "unity.h"
+#include "unity_internals.h"
 
 void setUp(void){};
 void tearDown(void){};
 
+void test_CPU_should_init() {
+  cpu *c = mgec_new_cpu();
+  TEST_ASSERT_EQUAL_INT16(c->pc, 0);
+  TEST_ASSERT_EQUAL_INT8(c->ac, 0);
+  TEST_ASSERT_EQUAL_INT8(c->x, 0);
+  TEST_ASSERT_EQUAL_INT8(c->y, 0);
+  TEST_ASSERT_EQUAL_INT8(c->sr, 0);
+  TEST_ASSERT_EQUAL_INT8(c->sp, 0);
+}
+
 int main() {
   UNITY_BEGIN();
+
+  RUN_TEST(test_CPU_should_init);
+
   return UNITY_END();
 }


### PR DESCRIPTION
This adds a basic test that matches what the proccessor is doing right now. As we get documented cpu states for different situations, we should document them as tests.

```
$ meson test -C build --print-errorlogs
ninja: Entering directory `/home/king/Projects/nono/mgec/build'
ninja: no work to do.
1/1 CPU Tests        OK              0.00s

Ok:                 1   
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   
```