### PR TITLE
Change registers of the CPU to that of a 65C816

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -159,7 +159,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
+PointerAlignment: Left
 PPIndentWidth:   -1
 QualifierAlignment: Leave
 ReferenceAlignment: Pointer

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -1,19 +1,92 @@
 #ifndef MGEC_CPU_H
 #define MGEC_CPU_H
 
-#include <stdint.h>
+#include "types.h"
 
-typedef uint8_t u8;
-typedef uint16_t u16;
-
+// The 65C816 CPU
 typedef struct _cpu {
+  // The 65C816 accumulator.
+  // In 8-bit mode, the only way to access the B register is by swapping its
+  // content with the A register. In 16-bit mode, the B and A registers are
+  // ganged to form the MSB and LSB respectively of the C register.
+  union {
+    struct {
+      u8 b;
+      u8 a;
+    };
+    u16 ac;
+  };
+
+  union {
+    struct {
+      // High byte of the X index register
+      u8 xh;
+      // Low byte of the X index register
+      u8 xl;
+    };
+    // X index register
+    u16 x;
+  };
+
+  union {
+    struct {
+      // High byte of the Y index register
+      u8 yh;
+      // Low byte of the Y index register
+      u8 yl;
+    };
+    // Y index register
+    u16 y;
+  };
+
+  union {
+    struct {
+      // Negative
+      u8 sr_n : 1;
+      // oVerflow
+      u8 sr_v : 1;
+      // accuMulator register size (native mode only; 0 = 16-bit, 1 = 8-bit)
+      u8 sr_m : 1;
+      // indeX register size (native mode only; 0 = 16-bit, 1 = 8-bit)
+      u8 sr_x : 1;
+      // Decimal mode
+      u8 sr_d : 1;
+      // Irq disable
+      u8 sr_i : 1;
+      // Zero
+      u8 sr_z : 1;
+      // Carry
+      u8 sr_c : 1;
+    };
+    // The 65C816 status register.
+    u8 sr;
+  };
+
+  // Emulation mode flag
+  // (This didn't fit in the status register back in the day, and you could only
+  // ever change the value in here by exchanging the carry flag with it.)
+  u8 e : 1;
+
+  union {
+    struct {
+      // High byte of the stack pointer. Set to 1 in emulation mode.
+      u8 sph;
+      // Low byte of the stack pointer.
+      u8 spl;
+    };
+    u16 sp;
+  };
+
+  // Direct Page pointer
+  u16 dp;
+  // Data bank register
+  u8 db;
+  // Program bank register
+  u8 pb;
+  // Program counter
   u16 pc;
-  u8 ac;
-  u8 x, y;
-  u8 sr;
-  u8 sp;
 } cpu;
 
-cpu *mgec_new_cpu();
+cpu* mgec_new_cpu();
 
 #endif

--- a/include/types.h
+++ b/include/types.h
@@ -1,0 +1,9 @@
+#ifndef MGEC_TYPES_H
+#define MGEC_TYPES_H
+
+#include <stdint.h>
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+
+#endif

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -2,18 +2,20 @@
 
 #include "cpu.h"
 
-cpu *mgec_new_cpu() {
+cpu* mgec_new_cpu() {
   // TODO: more comprehensive cpu init
-  cpu *c = malloc(sizeof(cpu));
+  cpu* c = malloc(sizeof(cpu));
   if (c == NULL)
     return NULL;
 
-  c->pc = 0;
-  c->ac = 0;
-  c->x = 0;
-  c->y = 0;
-  c->sr = 0;
-  c->sp = 0;
+  c->xh = 0;
+  c->yh = 0;
+  c->sr = 0x35;
+  c->sph = 0x01;
+  c->dp = 0;
+  c->pb = 0;
+  c->db = 0;
+  c->e = 1;
 
   return c;
 }

--- a/test/test_cpu.c
+++ b/test/test_cpu.c
@@ -2,17 +2,19 @@
 #include "unity.h"
 #include "unity_internals.h"
 
-void setUp(void){};
-void tearDown(void){};
+void setUp(void) {};
+void tearDown(void) {};
 
 void test_CPU_should_init() {
-  cpu *c = mgec_new_cpu();
-  TEST_ASSERT_EQUAL_INT16(c->pc, 0);
-  TEST_ASSERT_EQUAL_INT8(c->ac, 0);
-  TEST_ASSERT_EQUAL_INT8(c->x, 0);
-  TEST_ASSERT_EQUAL_INT8(c->y, 0);
-  TEST_ASSERT_EQUAL_INT8(c->sr, 0);
-  TEST_ASSERT_EQUAL_INT8(c->sp, 0);
+  cpu* c = mgec_new_cpu();
+  TEST_ASSERT_EQUAL_INT8(c->xh, 0);
+  TEST_ASSERT_EQUAL_INT8(c->yh, 0);
+  TEST_ASSERT_EQUAL_INT8(c->sr, 0x35);
+  TEST_ASSERT_EQUAL_INT8(c->sph, 1);
+  TEST_ASSERT_EQUAL_INT8(c->dp, 0);
+  TEST_ASSERT_EQUAL_INT8(c->pb, 0);
+  TEST_ASSERT_EQUAL_INT8(c->db, 0);
+  TEST_ASSERT_EQUAL_INT8(c->e, 1);
 }
 
 int main() {


### PR DESCRIPTION
Also updated the test for an initialised CPU, broke out the type definitions for u8 and u16 into their own file, and changed the formatting for pointer variables, because we both prefer the asterisk on the type name, not the variable name.